### PR TITLE
Update storage.js

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -271,7 +271,7 @@ Storage.prototype._modifyFile = function(file, options) {
  * @param options
  */
 Storage.prototype.upload = function(file, options) {
-    if (!options.method || options.method === protocol.FDFS_METHOD_UPLOAD) {
+    if (!options.method || options.method === protocol.FDFS_METHOD_UPLOAD_FILE) {
         var command = protocol.STORAGE_PROTO_CMD_UPLOAD_FILE;
         return this._uploadFile(command, file, options);
     } else if (options.method === protocol.FDFS_METHOD_UPLOAD_APPENDER_FILE) {


### PR DESCRIPTION
when I upload a file  with the option of `{ method:upload }`,it's given an error tips :`[Error: options.method must in ['upload', 'uploadAppender', 'append', 'modify'] ]`,so  I read the  README.md and find a  error  in the  source of  storage.js that protocol.FDFS_METHOD_UPLOAD in line 274  could't found in the file of  protocol.js  ,perhaps it should be  protocol.FDFS_METHOD_UPLOAD_FILE,so I  correct this!