### PR TITLE
debug: 修复严重bug

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -502,8 +502,14 @@ Storage.prototype.download = function(fileId, options) {
                         recvLength += data.length;
                         // 读取完毕
                         if (recvLength >= header.bodyLength) {
-                            protocol.closeSocket(socket);
-                            resolve();
+                            // 读取完毕要关闭文件。
+                            // 不关闭文件造成两种后果：1、文件句柄不释放，造成硬盘空间不释放。
+                            // 2、在文件还没有写完时候就返回文件,表现如express中返回图片只有一半。
+                            target.end();
+                            target.on('close', function () {
+                              protocol.closeSocket(socket);
+                              resolve();
+                            });
                         }
                     }
                 },


### PR DESCRIPTION
storage.download 写文件完毕要关闭文件。
不关闭文件造成两种后果：
1、文件句柄不释放，造成硬盘空间不释放。
2、在文件还没有写完时候就返回文件,表现如express中返回图片只有一半。