### PR TITLE
fix close define before end call

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -505,11 +505,11 @@ Storage.prototype.download = function(fileId, options) {
                             // 读取完毕要关闭文件。
                             // 不关闭文件造成两种后果：1、文件句柄不释放，造成硬盘空间不释放。
                             // 2、在文件还没有写完时候就返回文件,表现如express中返回图片只有一半。
-                            target.end();
                             target.on('close', function () {
-                              protocol.closeSocket(socket);
-                              resolve();
+                                protocol.closeSocket(socket);
+                                resolve();
                             });
+                            target.end();
                         }
                     }
                 },


### PR DESCRIPTION
修复在定义以前调用导致，close过快不会调用event触发的声明