### PR TITLE
添加获取文件buffer数据方法

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,16 @@ fdfs.download(fileId, {
 
 ```
 
+### 获取文件buffer数据
+```js
+fdfs.fetchBuffer(fileId).then(function(buffer) {
+    // 获取完成
+
+}).catch(function(err) {
+    console.error(err);
+);
+```
+
 ### 删除文件
 
 ```js

--- a/lib/fdfs.js
+++ b/lib/fdfs.js
@@ -211,6 +211,20 @@ FdfsClient.prototype.download = function(fileId, options) {
 };
 
 /**
+ * 获取文件buffer数据
+ * @param fileId - 文件id
+ * @returns {Promise<Buffer>} 文件buffer数据
+ */
+ FdfsClient.prototype.fetchBuffer = function(fileId) {
+    var _self = this;
+    return _self._getTracker().then(function(tracker) {
+        return tracker.getFetchStorage(fileId);
+    }).then(function(storage) {
+        return storage.fetchBuffer(fileId);
+    });
+};
+
+/**
  * 删除fileId指定的文件
  * @param fileId
  */

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -524,6 +524,65 @@ Storage.prototype.download = function(fileId, options) {
 };
 
 /**
+ * 返回文件buffer数据
+ * @param {string} fileId - 文件id
+ * @return {Promise<Buffer>} 文件响应buffer
+ */
+Storage.prototype.fetchBuffer = function(fileId) {
+    var _self = this;
+    return this._getConnection().then(function(socket) {
+        var gf = helpers.id2gf(fileId);
+        var charset = _self.config.charset;
+        // 封装header
+        var fnLength = Buffer.byteLength(gf.filename, charset);
+        var bodyLength = protocol.FDFS_PROTO_PKG_LEN_SIZE + protocol.FDFS_PROTO_PKG_LEN_SIZE + protocol.FDFS_GROUP_NAME_MAX_LEN + fnLength;
+        var header = protocol.packHeader(protocol.STORAGE_PROTO_CMD_DOWNLOAD_FILE, bodyLength, 0);
+
+        // 封装body
+        var body = new Buffer(bodyLength);
+        // 默认都填充上0
+        body.fill(0);
+        var groupBL = Buffer.byteLength(gf.group, charset);
+        body.write(gf.group, protocol.FDFS_PROTO_PKG_LEN_SIZE + protocol.FDFS_PROTO_PKG_LEN_SIZE, groupBL, charset);
+        body.write(gf.filename, protocol.FDFS_PROTO_PKG_LEN_SIZE + protocol.FDFS_PROTO_PKG_LEN_SIZE + protocol.FDFS_GROUP_NAME_MAX_LEN, fnLength, charset);
+
+        socket.write(Buffer.concat([header, body]));
+
+        return new Promise(function(resolve, reject) {
+            var header;
+            var buffer = Buffer.alloc(0);
+            protocol.recvPacket(
+                socket,
+                protocol.STORAGE_PROTO_CMD_RESP,
+                null,
+                function(err, data) {
+                    if (err) {
+                        reject(err);
+                        return;
+                    }
+                    // header
+                    if (!is.buffer(data)) {
+                        header = data;
+                        // body
+                    } else {
+                        buffer = Buffer.concat([buffer, data]);
+                        // 读取完毕
+                        if (buffer.length >= header.bodyLength) {
+                            // 读取完毕要关闭文件。
+                            // 不关闭文件造成两种后果：1、文件句柄不释放，造成硬盘空间不释放。
+                            // 2、在文件还没有写完时候就返回文件,表现如express中返回图片只有一半。
+                            protocol.closeSocket(socket);
+                            resolve(buffer);
+                        }
+                    }
+                },
+                true
+            );
+        });
+    });
+}
+
+/**
  * * STORAGE_PROTO_CMD_QUERY_FILE_INFO
      # function: query file info from storage server
      # request body:

--- a/test/FdfsTest.js
+++ b/test/FdfsTest.js
@@ -145,11 +145,21 @@ describe('test fdfs', function() {
         }).catch(done);
     });
 
-    it.only('listStorages', function(done) {
+    it('listStorages', function(done) {
         this.timeout(0);
         fdfs.listStorages('group1').then(function(res) {
             console.log(res);
             done();
+        }).catch(done);
+    });
+
+    it('fetchBuffer', function(done) {
+        this.timeout(0);
+        var fileId = 'group1/M00/00/00/wKgCm2CnbHWAX7ucAANuhwb0lyM783.pdf';
+        fdfs.fetchBuffer(fileId).then(function(buffer) {
+            fs.writeFile('./test.pdf', buffer, (err, result) => {
+                done(err);
+            });
         }).catch(done);
     });
 });


### PR DESCRIPTION
在web应用中，可能需要获取文件完成的buffer数据或者直接作为http请求的响应。
目前看没有直接的方法可以提供需要。
使用target作为http.ServerResponse不可用。原有使用isStream做检查，检查项必须是写流。而http.ServerResponse是流。
所以在原有基础上添加了一个fetchBuffer方法，获取文件所有的buffer数据。